### PR TITLE
Add html meta tag for viewport on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
 	<meta chartset="utf-8" />
 	<title>REDOKU</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<style>
 		body {
-			width: 500px;
 			margin: 0 auto;
 			text-align: center;
 		}


### PR DESCRIPTION
Thanks for creating this great puzzle! I like to play mini-puzzles like this on mobile e.g. when having to wait for a couple of minutes.

Unfortunately currently I had to zoom and move around a lot when opening redoku on my phone. Therefore I added a viewport meta tag and removed the fixed body width.

Screenshots of the behavior before and after the change:

| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/8c547e38-c8a3-4156-b7fa-1646fe929f38" height="400"/>| <img src="https://github.com/user-attachments/assets/c1fefb1a-177e-4b45-bcf3-640a8e513d87" height="400"/> |




